### PR TITLE
gcc build fixes for include paths and make file

### DIFF
--- a/h3m/h3mlib/BUILD/gcc/makefile
+++ b/h3m/h3mlib/BUILD/gcc/makefile
@@ -47,7 +47,22 @@ obj/%.o: ../../h3m_code/%.c | obj
     
 obj/%.o: ../../h3m_conversion/%.c | obj
 	$(CC) $< -c $(CFLAGS) -o $@
-    
+	
+obj/%.o: ../../h3m_editing/%.c | obj
+	$(CC) $< -c $(CFLAGS) -o $@
+	
+obj/%.o: ../../h3m_modembed/%.c | obj
+	$(CC) $< -c $(CFLAGS) -o $@
+	
+obj/%.o: ../../internal/%.c | obj
+	$(CC) $< -c $(CFLAGS) -o $@
+	
+obj/%.o: ../../io/%.c | obj
+	$(CC) $< -c $(CFLAGS) -o $@
+	
+obj/%.o: ../../utils/%.c | obj
+	$(CC) $< -c $(CFLAGS) -o $@
+	
 obj/%.o: ../../gen/%.c | obj
 	$(CC) $< -c $(CFLAGS) -o $@
 	

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_AI_H_DEF__
 #define __H3M_AI_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 #include "h3m_ai_custom_hero.h"
 #include "h3m_ai_hero_settings.h"
 #include "h3m_ai_lose_cond.h"

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_custom_hero.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_custom_hero.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_AI_CUSTOM_HERO_H_DEF__
 #define __H3M_AI_CUSTOM_HERO_H_DEF__
 
 // Included by h3m_ai.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_hero_settings.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_hero_settings.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-10-12
+// Created by John Ã…kerblom 2014-10-12
 
 #ifndef __H3M_AI_HERO_SETTINGS_H_DEF__
 #define __H3M_AI_HERO_SETTINGS_H_DEF__
 
 // Included by h3m_ai.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 #include "../common/h3m_common.h"
 
 #pragma pack(push, 1)

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_lose_cond.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_lose_cond.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_AI_LOSE_COND_H_DEF__
 #define __H3M_AI_LOSE_COND_H_DEF__
 
 // Included by h3m_ai.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_rumor.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_rumor.h
@@ -1,12 +1,12 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_AI_RUMOR_H_DEF__
 #define __H3M_AI_RUMOR_H_DEF__
 
 // Included by h3m_ai.h
 
-#include "../utils/msvc_comp_stdint.h"
-#include "../h3mlib.h"
+#include "../../utils/msvc_comp_stdint.h"
+#include "../../h3mlib.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_teams.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_teams.h
@@ -1,12 +1,12 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_AI_TEAMS_H_DEF__
 #define __H3M_AI_TEAMS_H_DEF__
 
 // Included by h3m_ai.h
 
-#include "../utils/msvc_comp_stdint.h"
-#include "../h3mlib.h"
+#include "../../utils/msvc_comp_stdint.h"
+#include "../../h3mlib.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_win_cond.h
+++ b/h3m/h3mlib/h3m_structures/additional_info/h3m_ai_win_cond.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_AI_WIN_COND_H_DEF__
 #define __H3M_AI_WIN_COND_H_DEF__
 
 // Included by h3m_ai.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/basic_info/h3m_bi.h
+++ b/h3m/h3mlib/h3m_structures/basic_info/h3m_bi.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-22
+// Created by John Ã…kerblom 2014-11-22
 
 #ifndef __H3M_BI_H_DEF__
 #define __H3M_BI_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/events/h3m_event.h
+++ b/h3m/h3mlib/h3m_structures/events/h3m_event.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-12-15
+// Created by John Ã…kerblom 2014-12-15
 
 #ifndef __H3M_EVENT_H_DEF__
 #define __H3M_EVENT_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 #include "h3m_event_body.h"
 
 #pragma pack(push, 1)

--- a/h3m/h3mlib/h3m_structures/events/h3m_event_body.h
+++ b/h3m/h3mlib/h3m_structures/events/h3m_event_body.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-12-15
+// Created by John Ã…kerblom 2014-12-15
 
 #ifndef __H3M_EVENT_BODY_H_DEF__
 #define __H3M_EVENT_BODY_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/object_attributes/h3m_oa.h
+++ b/h3m/h3mlib/h3m_structures/object_attributes/h3m_oa.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-12-15
+// Created by John Ã…kerblom 2014-12-15
 
 #ifndef __H3M_OA_H_DEF__
 #define __H3M_OA_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 #include "h3m_oa_body.h"
 
 #pragma pack(push, 1)

--- a/h3m/h3mlib/h3m_structures/object_attributes/h3m_oa_body.h
+++ b/h3m/h3mlib/h3m_structures/object_attributes/h3m_oa_body.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-12-15
+// Created by John Ã…kerblom 2014-12-15
 
 #ifndef __H3M_OA_BODY_H_DEF__
 #define __H3M_OA_BODY_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/object_details/h3m_od.h
+++ b/h3m/h3mlib/h3m_structures/object_details/h3m_od.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-12-15
+// Created by John Ã…kerblom 2014-12-15
 
 #ifndef __H3M_OD_H_DEF__
 #define __H3M_OD_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 #include "h3m_od_body_dynamic.h"
 #include "h3m_od_body_static.h"
 

--- a/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_static.h
+++ b/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_static.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-12-15
+// Created by John Ã…kerblom 2014-12-15
 
 #ifndef __H3M_OD_BODY_STATIC_H_DEF__
 #define __H3M_OD_BODY_STATIC_H_DEF__
 
 // Included by h3m_od.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/players/h3m_player.h
+++ b/h3m/h3mlib/h3m_structures/players/h3m_player.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-20
+// Created by John Ã…kerblom 2014-11-20
 
 #ifndef __H3M_PLAYER_H_DEF__
 #define __H3M_PLAYER_H_DEF__
 
 // Included by h3m.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 #include "h3m_player_ai.h"
 
 #pragma pack(push, 1)

--- a/h3m/h3mlib/h3m_structures/players/h3m_player_ai.h
+++ b/h3m/h3mlib/h3m_structures/players/h3m_player_ai.h
@@ -1,11 +1,11 @@
-// Created by John Åkerblom 2014-11-20
+// Created by John Ã…kerblom 2014-11-20
 
 #ifndef __H3M_PLAYER_AI_H_DEF__
 #define __H3M_PLAYER_AI_H_DEF__
 
 // Included by h3m_player.h
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #pragma pack(push, 1)
 

--- a/h3m/h3mlib/h3m_structures/tiles/h3m_tile.h
+++ b/h3m/h3mlib/h3m_structures/tiles/h3m_tile.h
@@ -1,9 +1,9 @@
-// Created by John Åkerblom 2014-11-20
+// Created by John Ã…kerblom 2014-11-20
 
 #ifndef __H3M_TILE_H_DEF__
 #define __H3M_TILE_H_DEF__
 
-#include "../utils/msvc_comp_stdint.h"
+#include "../../utils/msvc_comp_stdint.h"
 
 #define TERRAIN_TYPE_IS_VALID(T) \
     ((T.terrain_type <= T_ROCK)? 1 : 0)

--- a/h3m/h3mlib/io/h3mlib_io.c
+++ b/h3m/h3mlib/io/h3mlib_io.c
@@ -10,7 +10,7 @@
 #ifndef NO_ZLIB
 #include <gzip_utils.h>
 #else
-#include "gzip_empty/gzip_utils.h"
+#include "../utils/gzip_empty.h"
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
When trying to build project with gcc as described in "GCC simple build instructions" readme section build failed due to incorrect paths in some include instructions and incomplete make file (missing some folders). Overall gcc build seems a little bit outdated, so I prepared a small pull request with fixes which gives a working h3mhelloworld.exe and h3mlib.dll.  
Tested via gcc 4.9.2 and cygwin 2.4.1
Unfortunately **changes are not tested with Visual Studio** build , because I don't have any and Visual Studio Code is not working with .sln files :<
P.S. Sorry for a mess with "Created by" label, it seems all IDE's and text editors available for me are incompetent to work with 'Å' letter correctly.
