### PR TITLE
Fix seer huts

### DIFF
--- a/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj
+++ b/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj
@@ -82,6 +82,8 @@
     <ClInclude Include="..\..\h3m_constants\h3m_oa_class.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_skill.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_terrain.h" />
+    <ClInclude Include="..\..\h3m_constants\h3m_quest_objective.h" />
+    <ClInclude Include="..\..\h3m_constants\h3m_quest_reward.h" />
     <ClInclude Include="..\..\h3m_conversion\conv_tables_creatures.h" />
     <ClInclude Include="..\..\h3m_editing\default_od_body.h" />
     <ClInclude Include="..\..\h3m_editing\h3mlib_alg_od_text.h" />

--- a/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj.filters
+++ b/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj.filters
@@ -380,6 +380,12 @@
     <ClInclude Include="..\..\h3m_constants\h3m_artifact.h">
       <Filter>h3m_constants</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\h3m_constants\h3m_quest_reward.h">
+      <Filter>h3m_constants</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\h3m_constants\h3m_quest_objective.h">
+      <Filter>h3m_constants</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README" />

--- a/h3m/h3mlib/h3m_constants/h3m_constants.h
+++ b/h3m/h3mlib/h3m_constants/h3m_constants.h
@@ -11,5 +11,7 @@
 #include "h3m_oa_class.h"
 #include "h3m_skill.h"
 #include "h3m_terrain.h"
+#include "h3m_quest_objective.h"
+#include "h3m_quest_reward.h"
 
 #endif

--- a/h3m/h3mlib/h3m_constants/h3m_quest_objective.h
+++ b/h3m/h3mlib/h3m_constants/h3m_quest_objective.h
@@ -1,0 +1,15 @@
+#ifndef __H3M_QUEST_OBJECTIVE_H_DEF__
+#define __H3M_QUEST_OBJECTIVE_H_DEF__
+
+#define Q_NONE 0x00
+#define Q_EXPERIENCE 0x01
+#define Q_PRIMARY_SKILLS 0x02
+#define Q_DEFEAT_HERO 0x03
+#define Q_DEFEAT_MONSTER 0x04
+#define Q_ARTIFACTS 0x05
+#define Q_CREATURES 0x06
+#define Q_RESOURCES 0x07
+#define Q_BE_HERO 0x08
+#define Q_BE_PLAYER 0x09
+
+#endif

--- a/h3m/h3mlib/h3m_constants/h3m_quest_reward.h
+++ b/h3m/h3mlib/h3m_constants/h3m_quest_reward.h
@@ -1,0 +1,16 @@
+#ifndef __H3M_QUEST_REWARD_H_DEF__
+#define __H3M_QUEST_REWARD_H_DEF__
+
+#define R_NONE 0x00
+#define R_EXPERIENCE 0x01
+#define R_SPELL_POINTS 0x02
+#define R_MORALE 0x03
+#define R_LUCK 0x04
+#define R_RESOURCE 0x05
+#define R_PRIMARY_SKILL 0x06
+#define R_SECONDARY_SKILL 0x07
+#define R_ARTIFACT 0x08
+#define R_SPELL 0x09
+#define R_CREATURES 0x0A
+
+#endif

--- a/h3m/h3mlib/h3m_conversion/convert.c
+++ b/h3m/h3mlib/h3m_conversion/convert.c
@@ -251,29 +251,17 @@ static int _convert_oa_roe(struct H3MLIB_CTX *ctx_in,
         switch (oa_type) {
             // ABSOD objects to drop
         case META_OBJECT_PLACEHOLDER_HERO:      // TODO convert to random hero
-			continue;
         case META_OBJECT_ABANDONED_MINE_ABSOD:
-			continue;
         case META_OBJECT_ARTIFACT_AB:
-			continue;
         case META_OBJECT_ARTIFACT_SOD:
-			continue;
         case META_OBJECT_DWELLING_ABSOD:
-			continue;
         case META_OBJECT_GARRISON_ABSOD:
-			continue;
         case META_OBJECT_GENERIC_IMPASSABLE_TERRAIN_ABSOD:      // Not handled here
-			continue;
         case META_OBJECT_GENERIC_PASSABLE_TERRAIN_SOD:
-			continue;
         case META_OBJECT_GENERIC_VISITABLE_ABSOD:
-			continue;
         case META_OBJECT_RANDOM_DWELLING_ABSOD:
-			continue;
         case META_OBJECT_RANDOM_DWELLING_PRESET_LEVEL_ABSOD:
-			continue;
         case META_OBJECT_RANDOM_DWELLING_PRESET_ALIGNMENT_ABSOD:
-			continue;
         case META_OBJECT_QUEST_GUARD:   // Should be renamed with _ABSOD at end
 			continue;
 		case META_OBJECT_SEERS_HUT:
@@ -598,7 +586,7 @@ static int _od_body_conv(struct H3MLIB_CTX *ctx_in,
 
 	case META_OBJECT_SEERS_HUT:
 		is_conversion_failed = _inline_conv_seers_hut(ctx_in->h3m.format,
-			(struct H3M_OD_BODY_DYNAMIC_EVENT *)entry_out->body);
+			(struct H3M_OD_BODY_DYNAMIC_SEERS_HUT *)entry_out->body);
 		_reset_meta_push_od(ctx_out->h3m.format, entry_out->body, meta_out);
 		return is_conversion_failed;
     case META_OBJECT_GARRISON:

--- a/h3m/h3mlib/h3m_conversion/convert.c
+++ b/h3m/h3mlib/h3m_conversion/convert.c
@@ -263,9 +263,9 @@ static int _convert_oa_roe(struct H3MLIB_CTX *ctx_in,
         case META_OBJECT_RANDOM_DWELLING_PRESET_LEVEL_ABSOD:
         case META_OBJECT_RANDOM_DWELLING_PRESET_ALIGNMENT_ABSOD:
         case META_OBJECT_QUEST_GUARD:   // Should be renamed with _ABSOD at end
-			continue;
-		case META_OBJECT_SEERS_HUT:
-			break;
+            continue;
+        case META_OBJECT_SEERS_HUT:
+            break;
         case META_OBJECT_WITCH_HUT:     // No skill customization for RoE Witch Hut
             body_size_delta = -4;
             break;
@@ -531,30 +531,30 @@ static int _inline_conv_town(uint32_t fm_src,
 }
 
 static int _inline_conv_seers_hut(uint32_t fm_src,
-	struct H3M_OD_BODY_DYNAMIC_SEERS_HUT *body)
+    struct H3M_OD_BODY_DYNAMIC_SEERS_HUT *body)
 {
-	if ((enum H3M_FORMAT)fm_src > H3M_FORMAT_ROE)
-	{
-		if (NULL == body->artifact_type || NULL == body->quest_type)
-		{
-			return 1;
-		}
-		if (body->quest_type == Q_ARTIFACTS)
-		{
-			if (body->quest.objective->q_artifacts.count > 0)
-			{
-				enum H3M_ARTIFACT artifact = body->quest.objective->q_artifacts.artifacts[0];
-				// If artifact is not avaialable for quest in RoE than hut stays empty
-				if (artifact < H3M_ARTIFACT_CENTAUR_AXE || artifact > H3M_ARTIFACT_ORB_OF_INHIBITION)
-				{
-					return 1;
-				}
-				body->artifact_type = artifact;
-				return 0;
-			}
-		}
-	}
-	return 1;
+    if ((enum H3M_FORMAT)fm_src > H3M_FORMAT_ROE)
+    {
+        if (NULL == body->artifact_type || NULL == body->quest_type)
+        {
+            return 1;
+        }
+        if (body->quest_type == Q_ARTIFACTS)
+        {
+            if (body->quest.objective->q_artifacts.count > 0)
+            {
+                enum H3M_ARTIFACT artifact = body->quest.objective->q_artifacts.artifacts[0];
+                // If artifact is not avaialable for quest in RoE than hut stays empty
+                if (artifact < H3M_ARTIFACT_CENTAUR_AXE || artifact > H3M_ARTIFACT_ORB_OF_INHIBITION)
+                {
+                    return 1;
+                }
+                body->artifact_type = artifact;
+                return 0;
+            }
+        }
+    }
+    return 1;
 }
 
 static int _reset_meta_push_od(uint32_t fm_out, uint8_t *body,
@@ -581,14 +581,14 @@ static int _od_body_conv(struct H3MLIB_CTX *ctx_in,
 
     meta_out->has_absod_id = 0;
 
-	int is_conversion_failed = 0;
+    int is_conversion_failed = 0;
     switch (meta_in->oa_type) {
 
-	case META_OBJECT_SEERS_HUT:
-		is_conversion_failed = _inline_conv_seers_hut(ctx_in->h3m.format,
-			(struct H3M_OD_BODY_DYNAMIC_SEERS_HUT *)entry_out->body);
-		_reset_meta_push_od(ctx_out->h3m.format, entry_out->body, meta_out);
-		return is_conversion_failed;
+    case META_OBJECT_SEERS_HUT:
+        is_conversion_failed = _inline_conv_seers_hut(ctx_in->h3m.format,
+            (struct H3M_OD_BODY_DYNAMIC_SEERS_HUT *)entry_out->body);
+        _reset_meta_push_od(ctx_out->h3m.format, entry_out->body, meta_out);
+        return is_conversion_failed;
     case META_OBJECT_GARRISON:
         _inline_conv_army((union H3M_COMMON_ARMY *)&((union
                     H3M_OD_BODY_STATIC_GARRISON *)entry_out->body)->any.

--- a/h3m/h3mlib/h3m_conversion/convert.c
+++ b/h3m/h3mlib/h3m_conversion/convert.c
@@ -251,20 +251,33 @@ static int _convert_oa_roe(struct H3MLIB_CTX *ctx_in,
         switch (oa_type) {
             // ABSOD objects to drop
         case META_OBJECT_PLACEHOLDER_HERO:      // TODO convert to random hero
+			continue;
         case META_OBJECT_ABANDONED_MINE_ABSOD:
+			continue;
         case META_OBJECT_ARTIFACT_AB:
+			continue;
         case META_OBJECT_ARTIFACT_SOD:
+			continue;
         case META_OBJECT_DWELLING_ABSOD:
+			continue;
         case META_OBJECT_GARRISON_ABSOD:
+			continue;
         case META_OBJECT_GENERIC_IMPASSABLE_TERRAIN_ABSOD:      // Not handled here
+			continue;
         case META_OBJECT_GENERIC_PASSABLE_TERRAIN_SOD:
+			continue;
         case META_OBJECT_GENERIC_VISITABLE_ABSOD:
+			continue;
         case META_OBJECT_RANDOM_DWELLING_ABSOD:
+			continue;
         case META_OBJECT_RANDOM_DWELLING_PRESET_LEVEL_ABSOD:
+			continue;
         case META_OBJECT_RANDOM_DWELLING_PRESET_ALIGNMENT_ABSOD:
+			continue;
         case META_OBJECT_QUEST_GUARD:   // Should be renamed with _ABSOD at end
-        case META_OBJECT_SEERS_HUT:     // Simply drop for now... Vastly different in RoE with main problem being the other quest types
-            continue;
+			continue;
+		case META_OBJECT_SEERS_HUT:
+			break;
         case META_OBJECT_WITCH_HUT:     // No skill customization for RoE Witch Hut
             body_size_delta = -4;
             break;
@@ -330,6 +343,9 @@ static int _convert_oa_roe(struct H3MLIB_CTX *ctx_in,
                 entry_out->body.object_number = 1;
             }
         }
+	/*	else if (META_OBJECT_SEERS_HUT == oa_type) {
+
+		}*/
 
         entry_conv = calloc(1, sizeof(*entry_conv));
         entry_conv->oa_index_in = i;

--- a/h3m/h3mlib/h3m_conversion/convert.c
+++ b/h3m/h3mlib/h3m_conversion/convert.c
@@ -535,10 +535,6 @@ static int _inline_conv_seers_hut(uint32_t fm_src,
 {
     if ((enum H3M_FORMAT)fm_src > H3M_FORMAT_ROE)
     {
-        if (NULL == body->artifact_type || NULL == body->quest_type)
-        {
-            return 1;
-        }
         if (body->quest_type == Q_ARTIFACTS)
         {
             if (body->quest.objective->q_artifacts.count > 0)
@@ -551,6 +547,22 @@ static int _inline_conv_seers_hut(uint32_t fm_src,
                 }
                 body->artifact_type = artifact;
                 return 0;
+            }
+        }
+        if (body->reward_type == R_ARTIFACT)
+        {
+            enum H3M_ARTIFACT artifact = body->reward->r_artifact.absod;
+            if (artifact < H3M_ARTIFACT_CENTAUR_AXE || artifact > H3M_ARTIFACT_ORB_OF_INHIBITION)
+            {
+                return 1;
+            }
+        }
+        if (body->reward_type == R_CREATURES)
+        {
+            enum H3M_CREATURE creature = body->reward->r_creatures.absod.type;
+            if (creature > H3M_CREATURE_DIAMOND_GOLEM)
+            {
+                return 1;
             }
         }
     }

--- a/h3m/h3mlib/h3m_parsing/parse_od_seers_hut.c
+++ b/h3m/h3mlib/h3m_parsing/parse_od_seers_hut.c
@@ -2,18 +2,7 @@
 
 #include "parse_od.h"
 #include "parsing_common.h"
-
-#define R_NONE 0x00
-#define R_EXPERIENCE 0x01
-#define R_SPELL_POINTS 0x02
-#define R_MORALE 0x03
-#define R_LUCK 0x04
-#define R_RESOURCE 0x05
-#define R_PRIMARY_SKILL 0x06
-#define R_SECONDARY_SKILL 0x07
-#define R_ARTIFACT 0x08
-#define R_SPELL 0x09
-#define R_CREATURE 0x0A
+#include "../h3m_structures/object_details/h3m_od_body_ext_quest.h"
 
 #if 0
 struct REWARD_RESOURCE {
@@ -28,32 +17,36 @@ struct REWARD_PRIMARY_SKILL {
 
 size_t sizeof_reward(uint32_t fm, uint8_t reward_type)
 {
-    // TODO: change to be like _sizeof_win_cond in parse_ai_win_cond.c
-    // once there exists proper reward structs. format will probably be
-    // needed to decide sizes of some (creatures and artifacts)?
     switch (reward_type) {
     case R_NONE:
         return 0;
     case R_EXPERIENCE:
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_experience);
     case R_SPELL_POINTS:
-        return 4;
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_spell_points);
     case R_ARTIFACT:
-        return (fm == H3M_FORMAT_ROE) ? 1 : 2;
+		return (fm > H3M_FORMAT_ROE)
+			? sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_artifact.absod)
+			: sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_artifact.roe);
     case R_LUCK:
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_luck);
     case R_MORALE:
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_morale);
     case R_SPELL:
-        return 1;
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_spell);
     case R_RESOURCE:
-        return 5;
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_resource);
     case R_PRIMARY_SKILL:
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_primary_skill);
     case R_SECONDARY_SKILL:
-        return 2;
-    case R_CREATURE:
-        return (H3M_FORMAT_ROE == fm) ? 3 : 4;
+		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_secondary_skill);
+    case R_CREATURES:
+		return (fm > H3M_FORMAT_ROE)
+			? sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_creatures.absod)
+			: sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_creatures.roe);
     default:
         break;
     }
-
     return -1;
 }
 
@@ -77,7 +70,6 @@ int parse_od_seers_hut(struct H3MLIB_CTX *ctx,
     // tl;dr: For RoE quest type == artifact type of artifact quest
 
     SAFE_READ_SIZEOF(&body->quest_type, parsing)
-    // AB/SOD actually have several quest types, parse if quest_type is not 0
     if (fm >= H3M_FORMAT_AB && 0 != body->quest_type) {
         if (0 != parse_od_ext_quest(ctx, body->quest_type, &body->quest,
                 meta_od_entry)) {
@@ -87,7 +79,6 @@ int parse_od_seers_hut(struct H3MLIB_CTX *ctx,
 
     SAFE_READ_SIZEOF(&body->reward_type, parsing)
     if (0 != body->reward_type) {
-        // TODO have reward struct/union and actually parse rewards
         n = sizeof_reward(fm, body->reward_type);
         if (-1 == n || n > 5) {
             return 1;

--- a/h3m/h3mlib/h3m_parsing/parse_od_seers_hut.c
+++ b/h3m/h3mlib/h3m_parsing/parse_od_seers_hut.c
@@ -21,29 +21,29 @@ size_t sizeof_reward(uint32_t fm, uint8_t reward_type)
     case R_NONE:
         return 0;
     case R_EXPERIENCE:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_experience);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_experience);
     case R_SPELL_POINTS:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_spell_points);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_spell_points);
     case R_ARTIFACT:
-		return (fm > H3M_FORMAT_ROE)
-			? sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_artifact.absod)
-			: sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_artifact.roe);
+        return (fm > H3M_FORMAT_ROE)
+            ? sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_artifact.absod)
+            : sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_artifact.roe);
     case R_LUCK:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_luck);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_luck);
     case R_MORALE:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_morale);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_morale);
     case R_SPELL:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_spell);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_spell);
     case R_RESOURCE:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_resource);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_resource);
     case R_PRIMARY_SKILL:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_primary_skill);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_primary_skill);
     case R_SECONDARY_SKILL:
-		return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_secondary_skill);
+        return sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_secondary_skill);
     case R_CREATURES:
-		return (fm > H3M_FORMAT_ROE)
-			? sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_creatures.absod)
-			: sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_creatures.roe);
+        return (fm > H3M_FORMAT_ROE)
+            ? sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_creatures.absod)
+            : sizeof(((union H3M_OD_BODY_EXT_REWARD *) NULL)->r_creatures.roe);
     default:
         break;
     }

--- a/h3m/h3mlib/h3m_structures/common/h3m_common.h
+++ b/h3m/h3mlib/h3m_structures/common/h3m_common.h
@@ -73,14 +73,14 @@ struct H3M_COMMON_RESOURCES {
 
 // BINARY COMPATIBLE
 struct H3M_COMMON_RESOURCE {
-	uint8_t type;
-	uint32_t amount;
+    uint8_t type;
+    uint32_t amount;
 };
 
 struct H3M_COMMON_PRIMARY_SKILL
 {
-	uint8_t type;
-	uint8_t amount;
+    uint8_t type;
+    uint8_t amount;
 };
 
 // BINARY COMPATIBLE

--- a/h3m/h3mlib/h3m_structures/common/h3m_common.h
+++ b/h3m/h3mlib/h3m_structures/common/h3m_common.h
@@ -11,6 +11,7 @@
 
 typedef uint32_t H3M_COMMON_ABSOD_ID;
 typedef uint32_t H3M_COMMON_EXPERIENCE;
+typedef uint32_t H3M_COMMON_SPELL_POINTS;
 typedef uint16_t H3M_COMMON_ARTIFACT_TYPE_ABSOD;
 typedef uint16_t H3M_COMMON_CREATURE_TYPE_ABSOD;
 typedef uint8_t H3M_COMMON_ARTIFACT_TYPE_ROE;
@@ -18,6 +19,8 @@ typedef uint8_t H3M_COMMON_CREATURE_TYPE_ROE;
 typedef uint8_t H3M_COMMON_HERO_TYPE;
 typedef uint8_t H3M_COMMON_PLAYER_FLAG;
 typedef uint8_t H3M_COMMON_SPELL_TYPE;
+typedef uint8_t H3M_COMMON_MORALE;
+typedef uint8_t H3M_COMMON_LUCK;
 
 union H3M_COMMON_ARTIFACT_TYPE {
     H3M_COMMON_ARTIFACT_TYPE_ROE roe;
@@ -65,6 +68,19 @@ union H3M_COMMON_ARMY {
 // BINARY COMPATIBLE
 struct H3M_COMMON_RESOURCES {
     uint32_t resource[7];       // TODO split into respective resource
+};
+
+
+// BINARY COMPATIBLE
+struct H3M_COMMON_RESOURCE {
+	uint8_t type;
+	uint32_t amount;
+};
+
+struct H3M_COMMON_PRIMARY_SKILL
+{
+	uint8_t type;
+	uint8_t amount;
 };
 
 // BINARY COMPATIBLE

--- a/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_dynamic.h
+++ b/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_dynamic.h
@@ -96,7 +96,7 @@ struct H3M_OD_BODY_DYNAMIC_SEERS_HUT {
     };
     struct H3M_OD_BODY_EXT_QUEST quest; // AB/SOD feature, only if 0xFF != quest_type
     uint8_t reward_type;
-	union H3M_OD_BODY_EXT_REWARD *reward; // max size 5
+    union H3M_OD_BODY_EXT_REWARD *reward; // max size 5
     uint8_t unknown1[2];
 };
 

--- a/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_dynamic.h
+++ b/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_dynamic.h
@@ -96,8 +96,7 @@ struct H3M_OD_BODY_DYNAMIC_SEERS_HUT {
     };
     struct H3M_OD_BODY_EXT_QUEST quest; // AB/SOD feature, only if 0xFF != quest_type
     uint8_t reward_type;
-    // TODO reward union
-    uint8_t *reward;            // max size 5
+	union H3M_OD_BODY_EXT_REWARD *reward; // max size 5
     uint8_t unknown1[2];
 };
 

--- a/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_ext_quest.h
+++ b/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_ext_quest.h
@@ -58,24 +58,24 @@ struct H3M_OD_BODY_EXT_QUEST {
 };
 
 union H3M_OD_BODY_EXT_REWARD {
-	H3M_COMMON_EXPERIENCE r_experience;
-	H3M_COMMON_SPELL_POINTS r_spell_points;
-	H3M_COMMON_MORALE r_morale;
-	H3M_COMMON_LUCK r_luck;
-	struct H3M_COMMON_RESOURCE r_resource;
-	struct H3M_COMMON_PRIMARY_SKILL r_primary_skill;
-	struct H3M_COMMON_SECONDARY_SKILL r_secondary_skill;
-	union
-	{
-		H3M_COMMON_ARTIFACT_TYPE_ROE roe;
-		H3M_COMMON_ARTIFACT_TYPE_ABSOD absod;
-	} r_artifact;
-	H3M_COMMON_SPELL_TYPE r_spell;
-	union 
-	{
-		struct H3M_COMMON_CREATURE_SLOT_ROE roe;
-		struct H3M_COMMON_CREATURE_SLOT_ABSOD absod;
-	} r_creatures;
+    H3M_COMMON_EXPERIENCE r_experience;
+    H3M_COMMON_SPELL_POINTS r_spell_points;
+    H3M_COMMON_MORALE r_morale;
+    H3M_COMMON_LUCK r_luck;
+    struct H3M_COMMON_RESOURCE r_resource;
+    struct H3M_COMMON_PRIMARY_SKILL r_primary_skill;
+    struct H3M_COMMON_SECONDARY_SKILL r_secondary_skill;
+    union
+    {
+        H3M_COMMON_ARTIFACT_TYPE_ROE roe;
+        H3M_COMMON_ARTIFACT_TYPE_ABSOD absod;
+    } r_artifact;
+    H3M_COMMON_SPELL_TYPE r_spell;
+    union 
+    {
+        struct H3M_COMMON_CREATURE_SLOT_ROE roe;
+        struct H3M_COMMON_CREATURE_SLOT_ABSOD absod;
+    } r_creatures;
 };
 
 #pragma pack(pop)

--- a/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_ext_quest.h
+++ b/h3m/h3mlib/h3m_structures/object_details/h3m_od_body_ext_quest.h
@@ -25,17 +25,6 @@ struct H3M_OD_BODY_EXT_QUEST_CREATURES {
     struct H3M_COMMON_CREATURE_SLOT_ABSOD creatures[8]; // only <count entries> used
 };
 
-#define Q_NONE 0x00
-#define Q_EXPERIENCE 0x01
-#define Q_PRIMARY_SKILLS 0x02
-#define Q_DEFEAT_HERO 0x03
-#define Q_DEFEAT_MONSTER 0x04
-#define Q_ARTIFACTS 0x05
-#define Q_CREATURES 0x06
-#define Q_RESOURCES 0x07
-#define Q_BE_HERO 0x08
-#define Q_BE_PLAYER 0x09
-
 union H3M_OD_BODY_EXT_QUEST_OBJECTIVE {
     H3M_COMMON_EXPERIENCE q_any;
     H3M_COMMON_EXPERIENCE q_experience;
@@ -66,6 +55,27 @@ struct H3M_OD_BODY_EXT_QUEST_DEADLINE_AND_MESG {
 struct H3M_OD_BODY_EXT_QUEST {
     union H3M_OD_BODY_EXT_QUEST_OBJECTIVE *objective;
     struct H3M_OD_BODY_EXT_QUEST_DEADLINE_AND_MESG deadline_and_mesg;
+};
+
+union H3M_OD_BODY_EXT_REWARD {
+	H3M_COMMON_EXPERIENCE r_experience;
+	H3M_COMMON_SPELL_POINTS r_spell_points;
+	H3M_COMMON_MORALE r_morale;
+	H3M_COMMON_LUCK r_luck;
+	struct H3M_COMMON_RESOURCE r_resource;
+	struct H3M_COMMON_PRIMARY_SKILL r_primary_skill;
+	struct H3M_COMMON_SECONDARY_SKILL r_secondary_skill;
+	union
+	{
+		H3M_COMMON_ARTIFACT_TYPE_ROE roe;
+		H3M_COMMON_ARTIFACT_TYPE_ABSOD absod;
+	} r_artifact;
+	H3M_COMMON_SPELL_TYPE r_spell;
+	union 
+	{
+		struct H3M_COMMON_CREATURE_SLOT_ROE roe;
+		struct H3M_COMMON_CREATURE_SLOT_ABSOD absod;
+	} r_creatures;
 };
 
 #pragma pack(pop)

--- a/h3m/h3mlib/meta/meta_push_od.c
+++ b/h3m/h3mlib/meta/meta_push_od.c
@@ -272,8 +272,16 @@ static int _meta_push_od_seers_hut(uint32_t fm,
         (struct H3M_OD_BODY_DYNAMIC_QUEST_GUARD *)body, meta_od_entry);
 
     n = sizeof_reward(fm, body->reward_type);
-    META_OBJECT_PUSH_PTR(meta_od_entry->dyn_pointers, body, body->reward, n, 0)
-
+	// Convert AB/SoD 2-byte amounts to RoE 1-byte 
+	if (body->reward_type == R_CREATURES && fm == H3M_FORMAT_ROE)
+	{
+		body->reward->r_creatures.roe.quantity = (H3M_COMMON_CREATURE_TYPE_ROE)body->reward->r_creatures.absod.quantity;
+	}
+	if (body->reward_type == R_ARTIFACT && fm == H3M_FORMAT_ROE)
+	{
+		body->reward->r_artifact.roe = (H3M_COMMON_ARTIFACT_TYPE_ROE)body->reward->r_artifact.absod;
+	}
+	META_OBJECT_PUSH_PTR(meta_od_entry->dyn_pointers, body, body->reward, n, 0)
     return 0;
 }
 

--- a/h3m/h3mlib/meta/meta_push_od.c
+++ b/h3m/h3mlib/meta/meta_push_od.c
@@ -272,16 +272,16 @@ static int _meta_push_od_seers_hut(uint32_t fm,
         (struct H3M_OD_BODY_DYNAMIC_QUEST_GUARD *)body, meta_od_entry);
 
     n = sizeof_reward(fm, body->reward_type);
-	// Convert AB/SoD 2-byte amounts to RoE 1-byte 
-	if (body->reward_type == R_CREATURES && fm == H3M_FORMAT_ROE)
-	{
-		body->reward->r_creatures.roe.quantity = (H3M_COMMON_CREATURE_TYPE_ROE)body->reward->r_creatures.absod.quantity;
-	}
-	if (body->reward_type == R_ARTIFACT && fm == H3M_FORMAT_ROE)
-	{
-		body->reward->r_artifact.roe = (H3M_COMMON_ARTIFACT_TYPE_ROE)body->reward->r_artifact.absod;
-	}
-	META_OBJECT_PUSH_PTR(meta_od_entry->dyn_pointers, body, body->reward, n, 0)
+    // Convert AB/SoD 2-byte amounts to RoE 1-byte 
+    if (body->reward_type == R_CREATURES && fm == H3M_FORMAT_ROE)
+    {
+        body->reward->r_creatures.roe.quantity = (H3M_COMMON_CREATURE_TYPE_ROE)body->reward->r_creatures.absod.quantity;
+    }
+    if (body->reward_type == R_ARTIFACT && fm == H3M_FORMAT_ROE)
+    {
+        body->reward->r_artifact.roe = (H3M_COMMON_ARTIFACT_TYPE_ROE)body->reward->r_artifact.absod;
+    }
+    META_OBJECT_PUSH_PTR(meta_od_entry->dyn_pointers, body, body->reward, n, 0)
     return 0;
 }
 


### PR DESCRIPTION
- Fix for #4 issue - now seer huts with 'return artifact' quest type should converts correctly. If seer hut gives a quest which not supported by RoE/HD, or desired artifact is from AB/SoD, then hut stays empty, with no quest (will it be under #16 customization?).
- Moved constants for quests and rewards to separate .h files, so a couple of lines to h3lib project file.
- h3m_common provides a handful of useful types so I based fix on types from this file, but I also had to add types for: single resource slot, single primary skill slot, spell points, morale and luck.
