### PR TITLE
Fix for #15 conflux hero conversion crash

### DIFF
--- a/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj
+++ b/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj
@@ -79,6 +79,7 @@
     <ClInclude Include="..\..\h3m_constants\h3m_disposition.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_format.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_hero.h" />
+    <ClInclude Include="..\..\h3m_constants\h3m_hero_class.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_oa_class.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_skill.h" />
     <ClInclude Include="..\..\h3m_constants\h3m_terrain.h" />

--- a/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj.filters
+++ b/h3m/h3mlib/BUILD/VS/h3mlib.vcxproj.filters
@@ -380,6 +380,9 @@
     <ClInclude Include="..\..\h3m_constants\h3m_artifact.h">
       <Filter>h3m_constants</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\h3m_constants\h3m_hero_class.h">
+      <Filter>h3m_constants</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README" />

--- a/h3m/h3mlib/h3m_constants/h3m_constants.h
+++ b/h3m/h3mlib/h3m_constants/h3m_constants.h
@@ -8,6 +8,7 @@
 #include "h3m_disposition.h"
 #include "h3m_format.h"
 #include "h3m_hero.h"
+#include "h3m_hero_class.h"
 #include "h3m_oa_class.h"
 #include "h3m_skill.h"
 #include "h3m_terrain.h"

--- a/h3m/h3mlib/h3m_constants/h3m_hero_class.h
+++ b/h3m/h3mlib/h3m_constants/h3m_hero_class.h
@@ -1,0 +1,25 @@
+#ifndef __H3M_HERO_CLASS_H_DEF__
+#define __H3M_HERO_CLASS_H_DEF__
+
+enum H3M_HERO_CLASS {
+    H3M_HERO_KNIGHT,        /* 0x00 */
+    H3M_HERO_CLERIC,        /* 0x01 */
+    H3M_HERO_RANGER,        /* 0x02 */
+    H3M_HERO_DRUID,         /* 0x03 */
+    H3M_HERO_ALCHEMIST,     /* 0x04 */
+    H3M_HERO_WIZARD,        /* 0x05 */
+    H3M_HERO_DEMONIAC,      /* 0x06 */
+    H3M_HERO_HERETIC,       /* 0x07 */
+    H3M_HERO_DEATH_KNIGNT,  /* 0x08 */
+    H3M_HERO_NECROMANCER,   /* 0x09 */
+    H3M_HERO_OVERLORD,      /* 0x0a */
+    H3M_HERO_WARLOCK,       /* 0x0b */
+    H3M_HERO_BARBARIAN,     /* 0x0c */
+    H3M_HERO_BATTLE_MAGE,   /* 0x0d */
+    H3M_HERO_BEASTMASTER,   /* 0x0e */
+    H3M_HERO_WITCH,         /* 0x0f */
+    H3M_HERO_PLANESWALKER,  /* 0x10 */
+    H3M_HERO_ELEMENTALIST   /* 0x11 */
+};
+
+#endif

--- a/h3m/h3mlib/h3m_conversion/convert.c
+++ b/h3m/h3mlib/h3m_conversion/convert.c
@@ -318,16 +318,14 @@ static int _convert_oa_roe(struct H3MLIB_CTX *ctx_in,
             entry_out->body.object_class = 0x4D;
             entry_out->body.object_number = 0;
         }
-        // Conflux heroes hack, Conflux hero -> castle hero
-        else if (META_OBJECT_HERO == oa_type) {
-            if (0 == stricmp((char *)entry_out->header.def, "ah16_e.def")) {
+        // Conflux heroes hack, Conflux hero -> random hero
+        else if (META_OBJECT_HERO == oa_type) 
+        {
+            if ((enum H3M_HERO_CLASS)entry_out->body.object_number == H3M_HERO_PLANESWALKER || 
+                (enum H3M_HERO_CLASS)entry_out->body.object_number == H3M_HERO_ELEMENTALIST) {
                 snprintf((char *)entry_out->header.def, entry_out->header.def_size,
-                    "%s", "ah00_e.def");
-                entry_out->body.object_number = 0;
-            } else if (0 == stricmp((char *)entry_out->header.def, "ah17_e.def")) {
-                snprintf((char *)entry_out->header.def, entry_out->header.def_size,
-                    "%s", "ah01_e.def");
-                entry_out->body.object_number = 1;
+                    "%s", "ahrandom.def");
+                entry_out->body.object_class = 0x46;
             }
         }
 


### PR DESCRIPTION
- Fix #15 
- Conflux heroes now converts into random heroes instead of knights and clerics
- Add a enumeration for a heroe's classes hence changes in project files
