### PR TITLE
Fixed GCC 8 error.

### DIFF
--- a/h3m/h3mlib/h3mlib.c
+++ b/h3m/h3mlib/h3mlib.c
@@ -1067,7 +1067,7 @@ int h3m_desc_set(h3mlib_ctx_t ctx, const char *desc)
     size_t n = strlen(desc);
     ctx->h3m.bi.any.desc = (NULL == ctx->h3m.bi.any.desc) ?
         malloc(n + 1) : realloc(ctx->h3m.bi.any.desc, n + 1);
-    strncpy((char *)ctx->h3m.bi.any.desc, desc, n);
+    strncpy((char *)ctx->h3m.bi.any.desc, desc, n + 1);
     ctx->h3m.bi.any.desc_size = n;
 
     return 0;


### PR DESCRIPTION
In GCC8 (`8.2.1 20180831` to be exact), an error occurs:

```
h3mlib.c: In function ‘h3m_desc_set’:
h3mlib.c:1070:5: error: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
     strncpy((char *)ctx->h3m.bi.any.desc, desc, n);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
h3mlib.c:1067:16: note: length computed here
     size_t n = strlen(desc);
                ^~~~~~~~~~~~
```

Hopefully, it was easy to fix.