### PR TITLE
Specialized more cases in dispatchers.

### DIFF
--- a/h3m/h3mtilespritegen/dispatch_road_or_river.c
+++ b/h3m/h3mtilespritegen/dispatch_road_or_river.c
@@ -123,7 +123,6 @@ int dispatch_##TYPE(unsigned char adjacent,                                     
         POOL_CASE(N | W | NE, NESW_DIAGONAL_MIRR(M_HORI, M_VERT), pool_diagonals)      \
         POOL_CASE(N | W | SW, NESW_DIAGONAL_MIRR(M_HORI, M_VERT), pool_diagonals)      \
         POOL_CASE(N | NE | SW, NESW_DIAGONAL_MIRR(M_HORI, M_VERT), pool_diagonals)     \
-        POOL_CASE(W | NE | SW, NESW_DIAGONAL_MIRR(M_HORI, M_VERT), pool_diagonals)     \
                                                                                        \
         POOL_CASE(E | S | NE | SW, NESW_DIAGONAL_MIRR(M_HORI, M_VERT), pool_diagonals) \
         POOL_CASE(E | S | NE, NESW_DIAGONAL_MIRR(M_HORI, M_VERT), pool_diagonals)      \
@@ -169,9 +168,13 @@ int dispatch_##TYPE(unsigned char adjacent,                                     
         SINGLE_CASE(E, 0, SP_HORI_END)                                                 \
         SINGLE_CASE(NE | E | SE, 0, SP_HORI_END)                                       \
         SINGLE_CASE(NE | E, 0, SP_HORI_END)                                            \
+        SINGLE_CASE(NW | E, 0, SP_HORI_END)                                            \
         SINGLE_CASE(E | SE, 0, SP_HORI_END)                                            \
         SINGLE_CASE(W, M_HORI, SP_HORI_END)                                            \
         SINGLE_CASE(NW | W | SW, M_HORI, SP_HORI_END)                                  \
+        SINGLE_CASE(W | NE, M_HORI, SP_HORI_END)                                       \
+        SINGLE_CASE(W | NE | SW, M_HORI, SP_HORI_END)                                  \
+        SINGLE_CASE(NW | W | SW | NE, M_HORI, SP_HORI_END)                             \
         SINGLE_CASE(NW | W, M_HORI, SP_HORI_END)                                       \
         SINGLE_CASE(W | SW, M_HORI, SP_HORI_END)                                       \
         POOL_CASE(E | W, 0, pool_hori)                                                 \
@@ -204,6 +207,10 @@ int dispatch_##TYPE(unsigned char adjacent,                                     
         SINGLE_CASE(NW | N | NE, M_VERT, SP_VERT_END)                                  \
         SINGLE_CASE(NW | N, M_VERT, SP_VERT_END)                                       \
         SINGLE_CASE(N | NE, M_VERT, SP_VERT_END)                                       \
+        SINGLE_CASE(SE | N, M_VERT, SP_VERT_END)                                       \
+        SINGLE_CASE(SW | N, M_VERT, SP_VERT_END)                                       \
+        SINGLE_CASE(SE | N | NE | NW, M_VERT, SP_VERT_END)                             \
+        SINGLE_CASE(SW | N | NE | NW, M_VERT, SP_VERT_END)                             \
         POOL_CASE(S | N, 0, pool_vert)                                                 \
                                                                                        \
         /* Oh boy here we go, vertical continued */                                    \


### PR DESCRIPTION
As I'm working on the roads, I see more and more _weird_ paths. It would be the best, to get rid of the `default` clause (maybe put an error in there, or at least a flag to log these?), but it's really a lot of cases. Anyway, the next part is here.

Before:
![screenshot from 2018-10-08 00-34-44](https://user-images.githubusercontent.com/1379064/46587811-0a33c100-ca92-11e8-9079-2ed6ce1a05aa.png)

After:
![screenshot from 2018-10-08 00-34-08](https://user-images.githubusercontent.com/1379064/46587813-0dc74800-ca92-11e8-97e0-e589fffd80ff.png)