### PR TITLE
Manage stack improvements

### DIFF
--- a/hd_edition/hde_launcher_mod/guimod.cpp
+++ b/hd_edition/hde_launcher_mod/guimod.cpp
@@ -46,7 +46,7 @@ void GuiMod::createCheckOptions(QWidget *parent, const QFont &font, const QPalet
     const int checkX = 0x169;
     const int initialY = 0x35;
     const int incY = 24;
-    const char *options[] = { 
+    const char *options[] = {
         "Fullscreen|fullscreen",
         "Re-visitable Objects (re-visit with spacebar)|revisitable",
         "Extra Hotkeys "
@@ -79,7 +79,7 @@ void GuiMod::createCheckOptions(QWidget *parent, const QFont &font, const QPalet
         checkbox->setObjectName(QString(options[i]).split('|')[1] + QString("|check"));
 
         checked = defaults[i];
-        settings_get_int(SETTINGS_PATH, 
+        settings_get_int(SETTINGS_PATH,
             (QString("enable_") + QString(options[i]).split('|')[1]).toStdString().c_str(), (int *)&checked);
         checkbox->setChecked(checked);
 
@@ -155,13 +155,13 @@ void GuiMod::extendGui()
     browseBtn->show();
     browseBtn->setFont(fullscreenLbl->font());
     connect(browseBtn, SIGNAL(clicked()), this, SLOT(browseBtnClicked()));
-    
+
     QLabel *newFullscreenLbl = qobject_cast<QLabel *>(qtuFindChildWidget(m_main, "fullscreen|label"));
     newFullscreenLbl->setText(fullscreenLbl->text());
-    
+
     QCheckBox *newFullscreenBox = qobject_cast<QCheckBox *>(qtuFindChildWidget(m_main, "fullscreen|check"));
     newFullscreenBox->setChecked(fullscreenBox->isChecked());
-    
+
     // Connect new checkbox to the slot in the original executable
     connect(newFullscreenBox, SIGNAL(toggled(bool)), m_main, SLOT(fullscreenBoxToggled(bool)));
 
@@ -196,7 +196,7 @@ void GuiMod::playBtnClicked()
     settings_set_ascii(SETTINGS_PATH, "orig_maped_path", m_rmgEdit->text().toStdString().c_str());
     _applyCheckBoxSettings(m_main);
 
-    // Have the play function in the launcher executable get called, 
+    // Have the play function in the launcher executable get called,
     // launching HOMM3 2.0.exe
     QTimer::singleShot(0, m_main, "1playBtnClicked()");
 }
@@ -286,27 +286,31 @@ void GuiMod::hotkeysLinkActivated(const QString &link)
 
     QMessageBox *msg = new QMessageBox();
     msg->setIcon(QMessageBox::Question);
-    msg->setText("Quick Combat Battle Result Screen:\n"
+    msg->setText(
+        "Quick Combat Battle Result Screen:\n"
         "ESC: Re-play this battle without Quick Combat\n\n"
         "Hero Trade Screen:\n"
         "Q: Swap creatures and artifacts\n"
         "1: Move all creatures and artifacts to hero 1 (left)\n"
         "2: Move all creatures and artifacts to hero 2 (right)\n"
         "\nTown/Hero/Hero Trade Screen:\n"
-        "Ctrl+click: split clicked creature stack into as many stacks of 1 as possible\n"
+        "Ctrl+click: split 1 creature into free stack\n"
+        "Ctrl+Shift+click: split clicked creature stack into as many stacks of 1 as possible\n"
         "Shift+click: split clicked creature stack evenly\n"
-        "Alt+click: join all creatures of this type into this stack\n\n"
+        "Alt+click: join all creatures of this type into this stack\n"
+        "Delete+click: dismiss selected stack\n\n"
         "Moving last stack from hero to hero / town to hero: all creatures except 1 are moved (without mod nothing "
-        "happens when trying to move last stack)");
+        "happens when trying to move last stack)"
+    );
     msg->show();
 }
 
 GuiMod::GuiMod()
 {
-    
+
 }
 
 GuiMod::~GuiMod()
 {
-    
+
 }

--- a/hd_edition/hde_mod/mod/stack_split.c
+++ b/hd_edition/hde_mod/mod/stack_split.c
@@ -168,6 +168,17 @@ int delete_stack(int selected_slot, uint32_t *types, uint32_t *quantities)
     return 1;
 }
 
+// just 4 fun
+int increment_stack(int selected_slot, uint32_t *quantities)
+{
+    if (quantities[selected_slot] > 0)
+    {
+        quantities[selected_slot]++;
+    }
+
+    return 0;
+}
+
 boolean is_control_pressed()
 {
     return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
@@ -186,6 +197,11 @@ boolean is_alt_pressed()
 boolean is_delete_pressed()
 {
     return (GetAsyncKeyState(VK_DELETE) & 0x8000) != 0;
+}
+
+boolean is_f1_pressed()
+{
+    return (GetAsyncKeyState(VK_F1) & 0x8000) != 0;
 }
 
 // Important that this is stdcall since it is called from inline asm
@@ -225,6 +241,10 @@ int __stdcall logic_select_stack(struct HDE_HERO *hero, unsigned int selected_sl
     else if (is_delete_pressed())
     {
         return delete_stack(selected_slot, hero->creature_types, hero->creature_quantities);
+    }
+    else if (is_f1_pressed())
+    {
+        return increment_stack(selected_slot, hero->creature_quantities);
     }
 
     return 1;


### PR DESCRIPTION
Hi,

Please consider some improvements related to managing stacks in town/hero/trade cases:
1. add ability to split a single unit into free stack (Ctrl+click); change filling all free stacks with 1 creature hotkey to Ctrl+Shift+click
2. implement "dismiss stack" functionality (Delete+click)
3. fix stack division (Shift+click) to break down selected stack into 2
4. fix order of filling of free slots 
5. fix multiple function calls when managing stacks in hero case
